### PR TITLE
Rx Nano 4 button output should only go high for 210ms 

### DIFF
--- a/433mhz_Rolling_Code.ino
+++ b/433mhz_Rolling_Code.ino
@@ -297,11 +297,10 @@ void loop() {
 
 
   // activate Rx pins for 210ms based on buttons pressed on Tx
-
   digitalWrite(buttonAndOutputPins[buttons - 1], HIGH);
   debugChangesLoop("Buttons = %d pin %d value HIGH", buttons, buttonAndOutputPins[buttons -1]);
 
-  delay(1000);
+  delay(210);
   for (uint8_t i = 0; i < sizeofbuttonAndOutputPins; i++) {
     digitalWrite(buttonAndOutputPins[i], LOW);
   }


### PR DESCRIPTION
Rx Nano 4 button output should only go high for 210ms to match the original design of the RX480